### PR TITLE
默认禁用接口执行引擎的证书校验

### DIFF
--- a/core/api/teststep.py
+++ b/core/api/teststep.py
@@ -62,6 +62,7 @@ class ApiTestStep:
                 self.collector.others['data'] = str(self.collector.others['data']).encode("utf-8")
             if 'files' in self.collector.others and self.collector.others['files'] is not None:
                 self.pop_content_type()
+            self.collector.others['verify'] = False
             url = url_join(self.collector.url, self.collector.path)
             if int(self.collector.controller["sleepBeforeRun"]) > 0:
                 sleep(int(self.collector.controller["sleepBeforeRun"]))


### PR DESCRIPTION
感谢作者的开源，在试用平台的接口测试功能的过程中，发现一直提示证书错误，经排查，发现引擎默认没有关闭对证书的校验，只得手动修改。一般测试环境的证书大多都有些问题，建议默认禁用 requests 的证书校验。